### PR TITLE
Fix missing 'request' param in mod API GET handler.

### DIFF
--- a/src/routes/api/mods/+server.js
+++ b/src/routes/api/mods/+server.js
@@ -74,7 +74,7 @@ async function getImageFromZip(zipFile, file) {
     return "/mods/images/" + outputFile;
 }
 
-export async function GET() {
+export async function GET({ request }) {
     if (request.headers.get("authorization") !== "Bearer " + MODS_API_KEY) {
         return jsonWithStatus(401, { message: "Invalid API key" });
     }


### PR DESCRIPTION
Response wasn't declared 🙃

Tested with:
```js
const response = await fetch('http://localhost:5173/api/mods/', {
	headers: {
		'Authorization': 'Bearer APIKEYFROMENV',
	},
});

console.log(await response.json());
```

e.g.

```
{
  mods: [
    {
      id: '647033b07c9f1bd6cb4a9ee9',
      type: 'cards',
      name: 'HighRoad Series',
      shortname: 'LowRoad',
      description: 'Shift foes downwards!',
...
```