### PR TITLE
Allow specifying the path to preview/icon within the mod zip file.

### DIFF
--- a/src/routes/api/mods/+server.js
+++ b/src/routes/api/mods/+server.js
@@ -94,8 +94,6 @@ export async function PUT({ request }) {
         return jsonWithStatus(401, { message: "Invalid API key" });
     }
 
-    // TODO: Should mod names be unique or something?
-    // If so, then the filename hashing is unnecessary, since they can just be `files/modname.zip`, `images/modname-preview.zip` etc
     const input = await request.json();
 
     if (!input) {
@@ -118,6 +116,8 @@ export async function PUT({ request }) {
         const data = {
             ...input,
             id: undefined,
+            previewZipPath: undefined,
+            iconZipPath: undefined,
             author: input.author ? JSON.stringify(input.author) : undefined,
             chipInformation: input.chipInformation
                 ? JSON.stringify(input.chipInformation)
@@ -128,8 +128,8 @@ export async function PUT({ request }) {
         const downloadPath = await downloadFile(input.discordDownloadLink);
 
         const [previewImagePath, iconImagePath] = await Promise.all([
-            getImageFromZip("static" + downloadPath, "preview.png"),
-            getImageFromZip("static" + downloadPath, "icon.png"),
+            getImageFromZip("static" + downloadPath, input.previewZipPath ?? "preview.png"),
+            getImageFromZip("static" + downloadPath, input.iconZipPath ?? "icon.png"),
         ]);
 
         data.filePaths = JSON.stringify({


### PR DESCRIPTION
Went with new field names (`previewZipPath`/`iconZipPath`) instead of reusing `previewImageURL` and `iconImageURL` since those get saved to the DB.

Example:

```js
const response = await fetch('http://localhost:5173/api/mods/', {
    method: 'PUT',
    body: JSON.stringify({
        type: 'cards',
        name: 'HighRoad Series',
        shortname: 'LowRoad',
        description: 'Shift foes downwards!',
        discordDownloadLink:
            'https://cdn.discordapp.com/attachments/1056635057244225716/1056730595281092669/DarkFang.zip',
        previewZipPath: 'preview.png',
        iconZipPath: 'icon.png',
        author: {
            authorName: 'Hooviey',
            authorId: '736271336376107068',
            threadName: '[CUS] [CHIP] HighRoad Series',
            threadId: '940760757824552980',
            attachmentId: '940761031377059890',
            channelId: '865079018704994355',
        },
        chipInformation: {
            codes: ['*'],
            damage: 0,
            timeFreeze: true,
            element: 'None',
            secondaryElement: 'None',
            canBoost: true,
        },
    }),
    headers: {
        'Content-Type': 'application/json',
        'Authorization': 'Bearer TOKEN',
    },
});
```